### PR TITLE
SERV-701: Fix "Return value of JWT::getKey() must be an instance of Firebase\JWT\Key" error

### DIFF
--- a/src/Security/OpenIdConfigurationProvider.php
+++ b/src/Security/OpenIdConfigurationProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace ItkDev\OpenIdConnect\Security;
 
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use ItkDev\OpenIdConnect\Exception\CacheException;
 use ItkDev\OpenIdConnect\Exception\ClaimsException;
 use ItkDev\OpenIdConnect\Exception\CodeException;
@@ -373,7 +374,8 @@ class OpenIdConfigurationProvider extends AbstractProvider
                     if ($key['kty'] === 'RSA') {
                         $e = self::base64urlDecode($key['e']);
                         $n = self::base64urlDecode($key['n']);
-                        $keys[$kid] = XMLSecurityKey::convertRSA($n, $e);
+                        $publicKey = XMLSecurityKey::convertRSA($n, $e);
+                        $keys[$kid] = new Key($publicKey, 'RS256');
                     } else {
                         throw new KeyException('Unsupported key data for key id: ' . $kid);
                     }

--- a/tests/Security/OpenIdConfigurationProviderTest.php
+++ b/tests/Security/OpenIdConfigurationProviderTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Security;
 
+use Firebase\JWT\Key;
 use Firebase\JWT\SignatureInvalidException;
 use GuzzleHttp\ClientInterface;
+use Hamcrest\Matchers as m;
 use ItkDev\OpenIdConnect\Exception\ClaimsException;
 use ItkDev\OpenIdConnect\Exception\NegativeCacheDurationException;
 use ItkDev\OpenIdConnect\Exception\NegativeLeewayException;
@@ -221,7 +223,16 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
 
-        $mockJWT->shouldReceive('decode')->andReturn($mockClaims);
+        // Assert that 'decode' is called as decode(<string>, [<string>, <Firebase\JWT\Key>])
+        // @see https://github.com/firebase/php-jwt/issues/432
+        $mockJWT->shouldReceive('decode')
+            ->with(
+                \Mockery::type('string'),
+                m::hasKeyValuePair(
+                    '111111111111111111111111111111111111111111',
+                    m::anInstanceOf(Key::class)
+                )
+            )->andReturn($mockClaims);
 
         $claims = $this->provider->validateIdToken('token', self::NONCE);
 


### PR DESCRIPTION
https://jira.itkdev.dk/browse/DISPLAY-1039

The `3.2.0` release triggered this error when used:
```
Return value of JWT::getKey() must be an instance of Firebase\JWT\Key
```
which relates to https://github.com/firebase/php-jwt/issues/432.

Fixed by implementing `new Key($key, $algo)` as described in https://github.com/firebase/php-jwt/issues/432#issuecomment-1155029408