### PR TITLE
Handled an array of audiences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Handled an array of audiences on ID token.
+
 ## [4.0.1] - 2025-01-13
- - Fix create release action 
+ - Fix create release action
 
 ## [4.0.0] - 2025-01-11
  - Removed support for PHP 8.1 and 8.2 (BC)

--- a/src/Security/OpenIdConfigurationProvider.php
+++ b/src/Security/OpenIdConfigurationProvider.php
@@ -213,8 +213,11 @@ class OpenIdConfigurationProvider extends AbstractProvider
             $keys = $this->getJwtVerificationKeys();
             JWT::$leeway = $this->leeway;
             $claims = JWT::decode($idToken, $keys);
-            if ($claims->aud !== $this->clientId) {
-                throw new ClaimsException('ID token has incorrect audience: ' . $claims->aud);
+            // "aud" may be an array of strings or a single string
+            // (cf. https://openid.net/specs/openid-connect-core-1_0.html#IDToken).
+            $audiences = (array) $claims->aud;
+            if (!in_array($this->clientId, $audiences)) {
+                throw new ClaimsException('ID token has incorrect audience(s): ' . implode(', ', $audiences));
             }
             if ($claims->iss !== $this->getConfiguration('issuer')) {
                 throw new ClaimsException('ID token has incorrect issuer: ' . $claims->iss);


### PR DESCRIPTION
As per the [OpenID Connect Core spec](https://openid.net/specs/openid-connect-core-1_0.html), the `aud` claim on an ID token can be an array of strings:

> In the general case, the aud value is an array of case-sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case-sensitive string.

(cf. <https://openid.net/specs/openid-connect-core-1_0.html#IDToken>}.