### PR TITLE
Improve CI workflows and local dev tooling

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -18,7 +18,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
               with:
                   fetch-depth: 2
 

--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -41,7 +41,7 @@ jobs:
         strategy:
             fail-fast: false
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |
@@ -55,7 +55,7 @@ jobs:
         strategy:
             fail-fast: false
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |
@@ -70,7 +70,7 @@ jobs:
         strategy:
             fail-fast: false
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |

--- a/.github/workflows/github_build_release.yml
+++ b/.github/workflows/github_build_release.yml
@@ -16,7 +16,7 @@ jobs:
             APP_ENV: prod
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Create a release in GitHub
               run: gh release create ${{ github.ref_name }} --verify-tag --generate-notes

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -34,7 +34,7 @@ jobs:
             fail-fast: false
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
+              uses: actions/checkout@v6
 
             - name: Create docker network
               run: |

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -15,7 +15,7 @@ jobs:
         name: PHP - Check Coding Standards
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |
@@ -29,7 +29,7 @@ jobs:
         name: PHPStan
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |
@@ -65,7 +65,7 @@ jobs:
                       php: "8.5"
                       prefer: prefer-stable
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -31,7 +31,7 @@ jobs:
     yaml-lint:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v5
+            - uses: actions/checkout@v6
 
             - name: Create docker network
               run: |

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,4 +1,0 @@
-{
-  "default": true,
-  "line-length": { "code_blocks": false }
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bumped `actions/checkout` from v5 to v6 in all CI workflows
+- Added `ci` profile to docker-compose matrix services to avoid starting them during local development
+- Fixed `test:coverage` task to run via docker-compose with `XDEBUG_MODE=coverage`
+- Fixed `test:run` to remove stale `composer.lock` before `composer update`
+- Fixed `test:matrix:reset` to use `--profile ci` flag
+- Removed unused `.markdownlint.json`
+
 ## [4.1.0] - 2026-03-20
 
 - Achieved 100% test coverage (methods and lines)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -142,7 +142,7 @@ tasks:
     test:coverage:
         desc: Run tests with coverage
         cmds:
-            - "{{.PHP}} vendor/bin/phpunit --coverage-clover=coverage/unit.xml"
+            - "{{.DOCKER_COMPOSE}} exec -e XDEBUG_MODE=coverage phpfpm vendor/bin/phpunit --coverage-text --coverage-clover=coverage/unit.xml"
 
     test:run:
         desc: "Run tests for a PHP version and dependency set (e.g. task test:run PHP=8.4 DEPS=lowest)"
@@ -162,6 +162,7 @@ tasks:
                       cp /app/vendor/.composer.lock /app/composer.lock
                       composer install -q
                     else
+                      rm -f /app/composer.lock
                       composer update -q --{{.PREFER}}
                       cp /app/composer.lock /app/vendor/.composer.lock
                     fi'
@@ -170,7 +171,7 @@ tasks:
     test:matrix:reset:
         desc: Remove cached vendor volumes to force a fresh dependency resolve
         cmds:
-            - "{{.DOCKER_COMPOSE}} down --volumes"
+            - "{{.DOCKER_COMPOSE}} --profile ci down --volumes"
 
     test:matrix:
         desc: Run tests across all PHP versions (mirrors CI matrix)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,16 +30,22 @@ services:
         extends:
             service: phpfpm
         image: itkdev/php8.4-fpm:latest
+        profiles:
+            - ci
 
     phpfpm85:
         extends:
             service: phpfpm
         image: itkdev/php8.5-fpm:latest
+        profiles:
+            - ci
 
     # Test matrix services (PHP version × dependency set)
     phpfpm83-stable:
         extends:
             service: phpfpm
+        profiles:
+            - ci
         volumes:
             - .:/app
             - phpfpm83-stable-vendor:/app/vendor
@@ -48,6 +54,8 @@ services:
     phpfpm83-lowest:
         extends:
             service: phpfpm
+        profiles:
+            - ci
         volumes:
             - .:/app
             - phpfpm83-lowest-vendor:/app/vendor
@@ -56,6 +64,8 @@ services:
     phpfpm84-stable:
         extends:
             service: phpfpm84
+        profiles:
+            - ci
         volumes:
             - .:/app
             - phpfpm84-stable-vendor:/app/vendor
@@ -64,6 +74,8 @@ services:
     phpfpm84-lowest:
         extends:
             service: phpfpm84
+        profiles:
+            - ci
         volumes:
             - .:/app
             - phpfpm84-lowest-vendor:/app/vendor
@@ -72,6 +84,8 @@ services:
     phpfpm85-stable:
         extends:
             service: phpfpm85
+        profiles:
+            - ci
         volumes:
             - .:/app
             - phpfpm85-stable-vendor:/app/vendor
@@ -80,6 +94,8 @@ services:
     phpfpm85-lowest:
         extends:
             service: phpfpm85
+        profiles:
+            - ci
         volumes:
             - .:/app
             - phpfpm85-lowest-vendor:/app/vendor


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` from v5 to v6 across all GitHub Actions workflows
- Add `ci` profile to docker-compose matrix services so they don't start during local development
- Fix `test:coverage` task to run via docker-compose with `XDEBUG_MODE=coverage`
- Fix `test:run` to remove stale `composer.lock` before `composer update`
- Fix `test:matrix:reset` to use `--profile ci` flag
- Remove unused `.markdownlint.json` (linting config is in docker image)

## Test plan
- [ ] Verify CI workflows pass with `actions/checkout@v6`
- [ ] Confirm `docker compose up` no longer starts matrix services
- [ ] Run `task test:coverage` and verify coverage report is generated
- [ ] Run `task test:matrix` to confirm matrix tests still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)