### PR TITLE
Chain previous consistently and tighten @throws on public methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Chained `previous` consistently in `OpenIdConfigurationProvider` catch
+  blocks (`validateIdToken`, `getJwtVerificationKeys`, `fetchJsonResource`,
+  `getConfiguration`) so consumers can walk back to the underlying
+  Guzzle/firebase/PSR exception via `getPrevious()`
+- Tightened `@throws` phpdoc on public methods (`validateIdToken`,
+  `getIdToken`, `getBaseAuthorizationUrl`) to enumerate the actual
+  transitive exceptions instead of declaring only the parent type. Removed
+  the inaccurate `ClientExceptionInterface` declaration on `getIdToken`
+  (the catch-all wraps it as `CodeException` with the original chained)
+- Documented HTTP timeout/proxy/verify configuration via constructor `$options`
+  (capability already provided by league/oauth2-client; no code change)
 - Bumped `actions/checkout` from v5 to v6 in all CI workflows
 - Added `ci` profile to docker-compose matrix services to avoid starting them during local development
 - Fixed `test:coverage` task to run via docker-compose with `XDEBUG_MODE=coverage`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,33 @@ $provider = new OpenIdConfigurationProvider([
 ]);
 ```
 
+##### HTTP timeout, proxy, and TLS verification
+
+This library extends `league/oauth2-client`, which uses Guzzle for HTTP. To
+bound how long a request to the IdP can take (recommended for production),
+pass `timeout` (seconds) in the constructor `$options`:
+
+```php
+$provider = new OpenIdConfigurationProvider([
+    // ... required options ...
+    'timeout' => 5,
+    'proxy' => 'http://proxy.example.com:8080',
+    'verify' => true, // only consulted by Guzzle when proxy is set
+]);
+```
+
+`league/oauth2-client` whitelists exactly these three keys (`timeout`, `proxy`,
+`verify`) and forwards them to the underlying Guzzle client. Other Guzzle
+options (e.g. `connect_timeout`) are silently dropped.
+
+> **Why Guzzle and not Symfony HttpClient?**
+> `league/oauth2-client` hard-types its HTTP client as
+> `GuzzleHttp\ClientInterface`. Symfony HttpClient implements PSR-18 / HTTPlug,
+> not Guzzle's interface, and there is no maintained adapter going Symfony →
+> Guzzle. To plug in a non-Guzzle client you would need to write such an
+> adapter yourself and pass it via `$collaborators['httpClient']` to the
+> constructor.
+
 ##### Leeway
 
 To account for clock skew times between the signing and verifying servers,

--- a/src/Security/OpenIdConfigurationProvider.php
+++ b/src/Security/OpenIdConfigurationProvider.php
@@ -103,6 +103,11 @@ class OpenIdConfigurationProvider extends AbstractProvider
         return ['cacheItemPool', 'cacheDuration', 'openIDConnectMetadataUrl', 'leeway', 'allowHttp'];
     }
 
+    /**
+     * @throws CacheException
+     * @throws HttpException
+     * @throws JsonException
+     */
     public function getBaseAuthorizationUrl(): string
     {
         return $this->getConfiguration('authorization_endpoint');
@@ -197,7 +202,13 @@ class OpenIdConfigurationProvider extends AbstractProvider
      * @return object
      *                The JWT's payload as a PHP object
      *
-     * @throws ItkOpenIdConnectException
+     * @throws CacheException
+     * @throws ClaimsException
+     * @throws DecodeException
+     * @throws HttpException
+     * @throws JsonException
+     * @throws KeyException
+     * @throws ValidationException
      */
     public function validateIdToken(string $idToken, string $nonce): object
     {
@@ -222,7 +233,7 @@ class OpenIdConfigurationProvider extends AbstractProvider
 
             return $claims;
         } catch (\UnexpectedValueException $e) {
-            throw new ValidationException('ID token validation failed: '.$e->getMessage());
+            throw new ValidationException('ID token validation failed: '.$e->getMessage(), 0, $e);
         }
     }
 
@@ -235,8 +246,7 @@ class OpenIdConfigurationProvider extends AbstractProvider
      * @return string
      *                The ID token
      *
-     * @throws CodeException
-     * @throws ClientExceptionInterface
+     * @throws CodeException Wraps any \Exception thrown by token-endpoint HTTP, JSON parsing, or `getConfiguration()` (with `previous` chained)
      */
     public function getIdToken(string $code): string
     {
@@ -371,7 +381,7 @@ class OpenIdConfigurationProvider extends AbstractProvider
                 $this->cacheItemPool->save($item);
             }
         } catch (InvalidArgumentException $e) {
-            throw new CacheException($e->getMessage());
+            throw new CacheException($e->getMessage(), 0, $e);
         }
 
         return $keys;
@@ -418,9 +428,9 @@ class OpenIdConfigurationProvider extends AbstractProvider
 
             return $resource;
         } catch (ClientExceptionInterface $e) {
-            throw new HttpException($e->getMessage());
+            throw new HttpException($e->getMessage(), 0, $e);
         } catch (\JsonException $e) {
-            throw new JsonException($e->getMessage());
+            throw new JsonException($e->getMessage(), 0, $e);
         }
     }
 
@@ -461,7 +471,7 @@ class OpenIdConfigurationProvider extends AbstractProvider
 
             return $value;
         } catch (InvalidArgumentException $e) {
-            throw new CacheException($e->getMessage());
+            throw new CacheException($e->getMessage(), 0, $e);
         }
     }
 


### PR DESCRIPTION
Companion to itk-dev/openid-connect-bundle PRs #31 and #32.

## Summary

- All catch blocks in `OpenIdConfigurationProvider` (`validateIdToken`, `getJwtVerificationKeys`, `fetchJsonResource`, `getConfiguration`) now chain the original exception as `previous`. Previously only `getIdToken` did. Consumers can now walk back to the underlying Guzzle/firebase/PSR cause via `getPrevious()` — useful for logs, error reporters, and custom retry policies.
- `@throws` phpdoc on public methods now enumerates the actual transitive exceptions instead of declaring only the `ItkOpenIdConnectException` parent. Removed the inaccurate `ClientExceptionInterface` declaration on `getIdToken` (the catch-all wraps Guzzle exceptions as `CodeException` with the original chained, so the interface never actually surfaces).
- README adds a section documenting the existing `timeout` / `proxy` / `verify` support already provided by `league/oauth2-client` via constructor `$options`, plus a short note explaining why the stack uses Guzzle rather than Symfony HttpClient (`league/oauth2-client` hard-types its `httpClient` collaborator).

## Why

A consumer asked: "do we see meaningful exceptions on timeout / IdP errors?" The bundle PR (#32) lets specific exception subtypes bubble through the authenticator. This library PR closes the matching gap underneath: 4 of 5 catch blocks were dropping `previous`, breaking the exception chain at the library boundary.

## Backward compatibility

Additive only. The third constructor arg on `\Exception` is optional and was missing on these throws; passing it doesn't change anything for callers that don't read `getPrevious()`. Phpdoc tightening declares specific subtypes that already extend the previously-declared parent type — anything catching the parent keeps working. PhpStan in consumer apps may now flag missing catches that were previously hidden behind the parent declaration; that's the desired outcome.

Pre-existing security advisory in `robrichards/xmlseclibs <3.1.5` (CVE-2026-32313) is unrelated to this PR but causes `task lint:composer` to fail. Track separately.

## Test plan

- [x] `task test:coverage` — 43 tests pass; 100% coverage retained
- [x] `task analyze:php` — phpstan max level, no errors
- [x] `task lint:php`, `task lint:markdown`, `task lint:yaml` — clean
- [x] `task test:matrix` — all 6 PHP × deps combinations green
- [ ] (Pre-existing) `task lint:composer` blocked by `robrichards/xmlseclibs` advisory; not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)