### PR TITLE
Hotfix: bump robrichards/xmlseclibs to ^3.1.5 (CVE-2026-32313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.1] - 2026-05-07
+
+### Security
+
+- Bumped `robrichards/xmlseclibs` constraint to `^3.1.5` to address
+  [CVE-2026-32313](https://github.com/advisories/GHSA-4v26-v6cg-g6f9)
+  (high severity — missing AES-GCM authentication tag validation on
+  encrypted nodes). The library uses xmlseclibs only for RSA key
+  construction (`XMLSecurityKey::convertRSA`), but consumers are
+  protected against the encrypted-node decryption issue regardless.
+
 ## [4.1.0] - 2026-03-20
 
 - Achieved 100% test coverage (methods and lines)
@@ -132,7 +143,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file to hopefully serve as an evolving example of a
   standardized open source project CHANGELOG.
 
-[Unreleased]: https://github.com/itk-dev/openid-connect/compare/4.1.0...HEAD
+[Unreleased]: https://github.com/itk-dev/openid-connect/compare/4.1.1...HEAD
+[4.1.1]: https://github.com/itk-dev/openid-connect/compare/4.1.0...4.1.1
 [4.1.0]: https://github.com/itk-dev/openid-connect/compare/4.0.3...4.1.0
 [4.0.3]: https://github.com/itk-dev/openid-connect/compare/4.0.2...4.0.3
 [4.0.2]: https://github.com/itk-dev/openid-connect/compare/4.0.1...4.0.2

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "league/oauth2-client": "^2.6",
         "psr/cache": "^2.0 || ^3.0",
         "psr/http-client": "^1.0",
-        "robrichards/xmlseclibs": "^3.1"
+        "robrichards/xmlseclibs": "^3.1.5"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.50",


### PR DESCRIPTION
## Summary

Bump the `robrichards/xmlseclibs` constraint from `^3.1` to `^3.1.5` to address [CVE-2026-32313](https://github.com/advisories/GHSA-4v26-v6cg-g6f9) — high severity, missing AES-GCM authentication tag validation on encrypted nodes.

This is a hotfix off `main` for a 4.1.1 patch release.

## Why now

`composer audit` flags 3.1.0–3.1.4 as vulnerable. The previous `^3.1` constraint *allowed* the fixed 3.1.5 but did not require it; downstream consumers' fresh installs could still resolve to a vulnerable minor. PR #37 (exception flow) explicitly deferred this; addressing it here keeps the security fix on a clean release branch.

## Scope

- `composer.json`: `robrichards/xmlseclibs: ^3.1` → `^3.1.5`
- `CHANGELOG.md`: new `[4.1.1] - 2026-05-07` heading under `### Security`
- `composer.lock` is gitignored — refreshed locally only for verification; not in the commit

## Backward compatibility

xmlseclibs 3.1.5 is API-compatible with 3.1.x. This library uses only `XMLSecurityKey::convertRSA(string $n, string $e): string` (in `OpenIdConfigurationProvider::getJwtVerificationKeys()`), unchanged across the 3.1 series. Bumping the floor only forces a defensive update; no caller change required.

## Test plan

- [x] `task test:coverage` (with `XDEBUG_MODE=coverage`) — 43 tests, 100% coverage retained
- [x] `task analyze:php` — phpstan max level, no errors
- [x] `task lint:php` / `task lint:markdown` / `task lint:yaml` — clean
- [x] `task lint:composer` — `composer audit` reports **no security vulnerability advisories**
- [x] `task test:matrix` — all 6 PHP × deps combinations green

## After merge

1. Tag 4.1.1 (release workflow handles this from `main`).
2. Merge `main` back into `develop` so the bumped constraint carries forward to the open feature branches (PR #37 in particular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)