### PR TITLE
PR C: Narrow remaining claim accesses and test types for PHPStan max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after the document type rather than the individual key is more
   accurate. Consumers catching the marker are unaffected; consumers
   catching the concrete class need to swap the name.
+- `OpenIdConfigurationProvider::getJwtVerificationKeys` declares its
+  return type as `array<string, Key>` (was just `array`), matching
+  the actual shape the method builds. Lets `validateIdToken` pass
+  the cached keys to `JWT::decode` without a `mixed` flow at
+  `level: max`.
+- `OpenIdConfigurationProvider::validateIdToken` narrows its
+  `$claims` local via inline `@var \stdClass&object{aud, iss,
+  nonce}` so the spec-required claim accesses
+  (`$claims->aud` / `$claims->iss` / `$claims->nonce`) type-check at
+  `level: max`. No runtime change — these values are guaranteed
+  present and string-typed by the OIDC spec and `firebase/php-jwt`
+  already enforces JWT validity.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Documentation
 
+- Added a new "Exception handling" section to `README.md` describing the
+  marker interface, the SPL parents of each concrete, the PSR-18
+  co-implementation on `HttpException`, and the 4.x → 5.0 catch-block
+  migration. Also fixed the `validateIdToken` example to catch the
+  marker interface instead of the now-deprecated abstract.
 - Added class-level PHPDoc to every concrete exception in
   `src/Exception/` describing what it represents, when it's thrown,
   the rationale for its SPL parent type, and the boundary against
@@ -134,14 +139,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ItkDev\OpenIdConnect\Exception\ItkOpenIdConnectException` abstract
   class (catch `OpenIdConnectExceptionInterface` instead). Kept through
   5.x; removal scheduled for 6.0.
-
-### Documentation
-
-- Added a new "Exception handling" section to `README.md` describing the
-  marker interface, the SPL parents of each concrete, the PSR-18
-  co-implementation on `HttpException`, and the 4.x → 5.0 catch-block
-  migration. Also fixed the `validateIdToken` example to catch the
-  marker interface instead of the now-deprecated abstract.
 
 ### Tooling
 

--- a/src/Security/OpenIdConfigurationProvider.php
+++ b/src/Security/OpenIdConfigurationProvider.php
@@ -222,6 +222,7 @@ class OpenIdConfigurationProvider extends AbstractProvider
             // NB: JWT::$leeway is a static property shared across all instances.
             // Always set it immediately before decode to ensure the correct value.
             JWT::$leeway = $this->leeway;
+            /** @var \stdClass&object{aud: string|array<string>, iss: string, nonce: string} $claims */
             $claims = JWT::decode($idToken, $keys);
             // "aud" may be an array of strings or a single string
             // (cf. https://openid.net/specs/openid-connect-core-1_0.html#IDToken).
@@ -356,8 +357,8 @@ class OpenIdConfigurationProvider extends AbstractProvider
     /**
      * Get JWT verification keys from Azure Active Directory.
      *
-     * @return array
-     *               Array of keys
+     * @return array<string, Key>
+     *                            Array of keys indexed by JWK `kid`
      *
      * @throws OpenIdConnectExceptionInterface
      */
@@ -372,6 +373,7 @@ class OpenIdConfigurationProvider extends AbstractProvider
             $item = $this->cacheItemPool->getItem($cacheKey);
 
             if ($item->isHit()) {
+                /** @var array<string, Key> $keys (we only ever store this shape) */
                 $keys = (array) $item->get();
             } else {
                 $keysUri = $this->getConfiguration('jwks_uri');

--- a/tests/Security/OpenIdConfigurationProviderTest.php
+++ b/tests/Security/OpenIdConfigurationProviderTest.php
@@ -226,6 +226,7 @@ class OpenIdConfigurationProviderTest extends TestCase
 
     public function testValidateIdTokenSuccess(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
 
@@ -249,6 +250,7 @@ class OpenIdConfigurationProviderTest extends TestCase
 
     public function testValidateIdTokenFailure(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockJWT->shouldReceive('decode')->andThrow(SignatureInvalidException::class, 'Signature verification failed');
 
@@ -260,6 +262,7 @@ class OpenIdConfigurationProviderTest extends TestCase
 
     public function testValidateIdTokenAudience(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
         $mockClaims->aud = 'incorrect aud';
@@ -274,6 +277,7 @@ class OpenIdConfigurationProviderTest extends TestCase
 
     public function testValidateIdTokenIssuer(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
         $mockClaims->iss = 'incorrect iss';
@@ -288,6 +292,7 @@ class OpenIdConfigurationProviderTest extends TestCase
 
     public function testValidateIdTokenNonce(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
         $mockClaims->nonce = 'incorrect nonce';
@@ -429,11 +434,13 @@ class OpenIdConfigurationProviderTest extends TestCase
         $method = new \ReflectionMethod(OpenIdConfigurationProvider::class, 'createResourceOwner');
 
         $owner = $method->invoke($this->provider, ['id' => '123', 'name' => 'Test'], $token);
+        $this->assertInstanceOf(\League\OAuth2\Client\Provider\ResourceOwnerInterface::class, $owner);
         $this->assertSame('123', $owner->getId());
     }
 
     public function testValidateIdTokenArrayAudience(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
         $mockClaims->aud = [self::CLIENT_ID, 'other_client'];
@@ -449,6 +456,7 @@ class OpenIdConfigurationProviderTest extends TestCase
 
     public function testValidateIdTokenArrayAudienceInvalid(): void
     {
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
         $mockClaims->aud = ['wrong_client_1', 'wrong_client_2'];
@@ -847,6 +855,7 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
 
         $this->expectException(JwksException::class);
@@ -892,6 +901,7 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
 
         $this->expectException(JwksException::class);
@@ -937,6 +947,7 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockClaims = $this->getMockClaims();
         $mockJWT->shouldReceive('decode')->andReturn($mockClaims);
@@ -1050,6 +1061,7 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
+        /** @var \Mockery\MockInterface $mockJWT */
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
 
         $this->expectException(\ItkDev\OpenIdConnect\Exception\DecodeException::class);
@@ -1070,7 +1082,7 @@ class OpenIdConfigurationProviderTest extends TestCase
      * unreadable / not valid JSON, rather than letting `false` or `null` flow
      * silently into the assertion under test.
      *
-     * @return array<string, mixed>
+     * @return array<mixed> top-level decoded JSON; callers cast / narrow as needed
      */
     private function loadMockFixture(string $filename): array
     {


### PR DESCRIPTION
## Summary

Third and final follow-up in the A → B → C sequence tightening the JSON-payload boundary on the path to `level: max` PHPStan.

After PR A (#43, constructor option shapes), PR #42 (string-cast guards + `MetadataException`), and PR B (#44, JSON-payload narrowing + `JwksException` + exception documentation), 15 max-level errors remain (out of the original 26 — 7 of those are in scope here, 4 are PR A's, and 4 disappear once both branches are on develop). This PR clears the 15 in scope.

> **Stacked on PR #44** — based on `feature/json-payload-narrowing`. When PR #42 / PR B merge, this PR rebases onto develop cleanly. The 4 max-level constructor errors (`$cacheItemPool`, `$cacheDuration`, `$factory`, `$url` at lines 78/81/95/98) are fixed by **PR A (#43)** — when both A and C merge, develop reaches zero max-level errors.

## What changes

### src/

- `getJwtVerificationKeys()` declares `@return array<string, Key>` (was `array`). Matches the shape the method builds; lets `validateIdToken` pass the keys to `JWT::decode` without a `mixed` flow. Cache-hit branch's `(array) $item->get()` gets an inline `@var` of the same shape — we only ever store this structure.
- `validateIdToken()` declares `$claims` with `\stdClass&object{aud: string|array<string>, iss: string, nonce: string}` after `JWT::decode`. Spec-required claim types; `firebase/php-jwt` already validates JWT structure before this point. No runtime change.

### tests/

- `testCreateResourceOwner` adds an `assertInstanceOf(ResourceOwnerInterface::class, $owner)` guard so `$owner->getId()` type-checks (the value comes back from `ReflectionMethod::invoke()` which is `mixed`).
- `loadMockFixture()`'s `@return` relaxed from `array<string, mixed>` to `array<mixed>` — `json_decode($content, true)` doesn't statically guarantee string keys; callers cast / narrow as needed.
- All 11 `$mockJWT = \Mockery::mock('overload:Firebase\\JWT\\JWT', MockJWT::class)` sites get an inline `/** @var \Mockery\MockInterface $mockJWT */` annotation. `phpstan/phpstan-mockery` doesn't recognise the `overload:` mock-syntax (overload mocks are special-cased not to instantiate the target class, so the extension's class-resolution doesn't fire). The annotation gives PHPStan enough type information to type-check the chained `shouldReceive(...)->...` calls.

## Test plan

- [x] `task test:coverage` — 100% on `OpenIdConfigurationProvider` (24/24 methods, 161/161 lines).
- [x] `task analyze:php` at `level: 8` — no errors.
- [x] `task analyze:php` at `level: max` — 4 errors remain, all in `OpenIdConfigurationProvider::__construct` (PR A's scope).
- [x] `task lint:php` — clean.
- [x] `task lint:markdown` — clean.
- [ ] CI matrix on PR.

## Final `level: max` bump

Left as a separate one-line follow-up so the bump lands independently of its prerequisites:

```diff
- level: 8
+ level: max
```

Order: PR A merges, PR #42 / PR B / PR C merge (each rebasing as their dependencies land), then the one-line bump PR. After that bump, the codebase is at PHPStan's strictest level with zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)