### PR TITLE
Bump PHPStan to level: max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tooling
 
+- Bumped PHPStan from `level: 8` to `level: max` in `phpstan.neon`.
+  The preceding PRs in the 5.0 series (constructor option shapes,
+  JSON-payload narrowing, claim shape on `validateIdToken`, JWKS
+  validation, test-side Mockery / fixture / claim narrowings) cleared
+  every max-level error; the bump is the final one-line config
+  change that locks in the strictest analysis level for future
+  contributions.
 - `OpenIdConfigurationProvider::__construct` now declares an
   `array{cacheItemPool?: CacheItemPoolInterface,
   openIDConnectMetadataUrl?: string, cacheDuration?: int, leeway?: int,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,7 +2,7 @@ includes:
 	- vendor/phpstan/phpstan-mockery/extension.neon
 
 parameters:
-	level: 8
+	level: max
 	paths:
 		- src
 		- tests


### PR DESCRIPTION
## Summary

Final one-line follow-up of the A → B → C series. The 5.0 PRs cleared every max-level PHPStan error in turn; this PR flips `phpstan.neon` from `level: 8` to `level: max` so the strictest analysis level is locked in for future contributions.

```diff
- level: 8
+ level: max
```

## How we got here

- **PR #43** typed the constructor `$options` / `$collaborators` array shapes (4 errors).
- **PR #42** + **PR #44** narrowed JSON payload accesses and introduced `MetadataException` / `JwksException` for malformed IdP payloads (~9 errors).
- **PR #45** declared `getJwtVerificationKeys` as `array<string, Key>`, annotated `validateIdToken`'s `$claims` with a `\stdClass & object{aud, iss, nonce}` shape, and added Mockery overload `@var` annotations on every test mock (the remaining ~7 errors).

## Effect going forward

Any future PR that reintroduces a `mixed` flow, an untyped array key access, a missing `@throws`, or any of the other strictness-rule violations now fails CI before review. The codebase is locked at PHPStan's highest level.

## Test plan

- [x] `task analyze:php` at `level: max` — no errors.
- [x] `task test:coverage` — 100% on `OpenIdConfigurationProvider` (24/24 methods, 161/161 lines).
- [x] `task lint:php` — clean.
- [x] `task lint:markdown` — clean.
- [ ] CI matrix on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)