### PR TITLE
test: assert full exception messages, codes and previous-chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Strengthened exception assertions guided by mutation testing: thrown
+  messages are asserted in full (including dynamic parts), wrap-boundary
+  exceptions assert code `0` and the chained `$previous` cause, and
+  invalid JSON from the token endpoint is covered
+
 ## [5.0.0] - 2026-06-02
 
 Reworked exception hierarchy and tightened IdP-payload validations. The runtime

--- a/tests/Security/OpenIdConfigurationProviderTest.php
+++ b/tests/Security/OpenIdConfigurationProviderTest.php
@@ -254,10 +254,16 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
         $mockJWT->shouldReceive('decode')->andThrow(SignatureInvalidException::class, 'Signature verification failed');
 
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('ID token validation failed');
+        try {
+            $this->provider->validateIdToken('token', self::NONCE);
+        } catch (ValidationException $thrown) {
+            $this->assertSame('ID token validation failed: Signature verification failed', $thrown->getMessage());
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertInstanceOf(SignatureInvalidException::class, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $this->provider->validateIdToken('token', self::NONCE);
+            return;
+        }
+        $this->fail('Expected ValidationException');
     }
 
     public function testValidateIdTokenAudience(): void
@@ -270,7 +276,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT->shouldReceive('decode')->andReturn($mockClaims);
 
         $this->expectException(ClaimsException::class);
-        $this->expectExceptionMessage('ID token has incorrect audience');
+        $this->expectExceptionMessage('ID token has incorrect audience(s): incorrect aud');
 
         $this->provider->validateIdToken('token', self::NONCE);
     }
@@ -285,7 +291,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT->shouldReceive('decode')->andReturn($mockClaims);
 
         $this->expectException(ClaimsException::class);
-        $this->expectExceptionMessage('ID token has incorrect issuer');
+        $this->expectExceptionMessage('ID token has incorrect issuer: incorrect iss');
 
         $this->provider->validateIdToken('token', self::NONCE);
     }
@@ -300,7 +306,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT->shouldReceive('decode')->andReturn($mockClaims);
 
         $this->expectException(ClaimsException::class);
-        $this->expectExceptionMessage('ID token has incorrect nonce');
+        $this->expectExceptionMessage('ID token has incorrect nonce: incorrect nonce');
 
         $this->provider->validateIdToken('token', self::NONCE);
     }
@@ -310,7 +316,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockCacheItemPool = $this->createStub(CacheItemPoolInterface::class);
 
         $this->expectException(BadUrlException::class);
-        $this->expectExceptionMessage('OpenIDConnectMetadataUrl is invalid');
+        $this->expectExceptionMessage('OpenIDConnectMetadataUrl is invalid: not-a-valid-url');
 
         new OpenIdConfigurationProvider([
             'cacheItemPool' => $mockCacheItemPool,
@@ -323,7 +329,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockCacheItemPool = $this->createStub(CacheItemPoolInterface::class);
 
         $this->expectException(IllegalSchemeException::class);
-        $this->expectExceptionMessage('OpenIDConnectMetadataUrl must use https');
+        $this->expectExceptionMessage('OpenIDConnectMetadataUrl must use https: http://some.url/openid-configuration');
 
         new OpenIdConfigurationProvider([
             'cacheItemPool' => $mockCacheItemPool,
@@ -421,10 +427,15 @@ class OpenIdConfigurationProviderTest extends TestCase
 
         $method = new \ReflectionMethod(OpenIdConfigurationProvider::class, 'checkResponse');
 
-        $this->expectException(IdentityProviderException::class);
-        $this->expectExceptionMessage('400');
+        try {
+            $method->invoke($this->provider, $response, []);
+        } catch (IdentityProviderException $thrown) {
+            $this->assertSame('400', $thrown->getMessage());
+            $this->assertSame(0, $thrown->getCode());
 
-        $method->invoke($this->provider, $response, []);
+            return;
+        }
+        $this->fail('Expected IdentityProviderException');
     }
 
     public function testCreateResourceOwner(): void
@@ -464,7 +475,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT->shouldReceive('decode')->andReturn($mockClaims);
 
         $this->expectException(ClaimsException::class);
-        $this->expectExceptionMessage('ID token has incorrect audience');
+        $this->expectExceptionMessage('ID token has incorrect audience(s): wrong_client_1, wrong_client_2');
 
         $this->provider->validateIdToken('token', self::NONCE);
     }
@@ -547,10 +558,71 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
-        $this->expectException(CodeException::class);
-        $this->expectExceptionMessage('Get ID token failed');
+        try {
+            $provider->getIdToken('test-code');
+        } catch (CodeException $thrown) {
+            $this->assertSame('Get ID token failed: Connection failed', $thrown->getMessage());
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertInstanceOf(ClientExceptionInterface::class, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $provider->getIdToken('test-code');
+            return;
+        }
+        $this->fail('Expected CodeException');
+    }
+
+    public function testGetIdTokenRejectsInvalidJsonResponse(): void
+    {
+        $tokenEndpoint = 'https://azure_b2c_test.b2clogin.com/azure_b2c_test.onmicrosoft.com/oauth2/v2.0/token?p=test-policy';
+        $openIDConnectMetadataUrl = 'https://some.url/openid-configuration';
+
+        $mockConfigResponse = $this->getMockHttpSuccessResponse('/../MockData/mockOpenIDConfiguration.json');
+
+        $malformedTokenResponseBody = 'not valid json{{{';
+        $mockTokenStream = $this->createStub(StreamInterface::class);
+        $mockTokenStream->method('getContents')->willReturn($malformedTokenResponseBody);
+        $mockTokenStream->method('__toString')->willReturn($malformedTokenResponseBody);
+
+        $mockTokenResponse = $this->createStub(ResponseInterface::class);
+        $mockTokenResponse->method('getStatusCode')->willReturn(200);
+        $mockTokenResponse->method('getBody')->willReturn($mockTokenStream);
+
+        $mockHttpClient = $this->createStub(ClientInterface::class);
+        $mockHttpClient->method('request')->willReturnMap([
+            ['GET', $openIDConnectMetadataUrl, [], $mockConfigResponse],
+            ['POST', $tokenEndpoint, ['form_params' => [
+                'client_id' => self::CLIENT_ID,
+                'client_secret' => self::CLIENT_SECRET,
+                'redirect_uri' => self::REDIRECT_URI,
+                'grant_type' => 'authorization_code',
+                'code' => 'test-code',
+            ]], $mockTokenResponse],
+        ]);
+
+        $mockCacheItem = $this->createStub(CacheItemInterface::class);
+        $mockCacheItem->method('isHit')->willReturn(false);
+
+        $mockCacheItemPool = $this->createStub(CacheItemPoolInterface::class);
+        $mockCacheItemPool->method('getItem')->willReturn($mockCacheItem);
+
+        $provider = new OpenIdConfigurationProvider([
+            'openIDConnectMetadataUrl' => $openIDConnectMetadataUrl,
+            'cacheItemPool' => $mockCacheItemPool,
+            'clientId' => self::CLIENT_ID,
+            'clientSecret' => self::CLIENT_SECRET,
+            'redirectUri' => self::REDIRECT_URI,
+        ], [
+            'httpClient' => $mockHttpClient,
+        ]);
+
+        try {
+            $provider->getIdToken('test-code');
+        } catch (CodeException $thrown) {
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertInstanceOf(\JsonException::class, $thrown->getPrevious(), 'Original cause must be chained');
+
+            return;
+        }
+        $this->fail('Expected CodeException');
     }
 
     public function testGetIdTokenRejectsResponseWithoutStringIdToken(): void
@@ -698,7 +770,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         ]);
 
         $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Cannot access json resource');
+        $this->expectExceptionMessage('Cannot access json resource: https://some.url/openid-configuration');
 
         $provider->getBaseAuthorizationUrl();
     }
@@ -728,10 +800,16 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
-        $this->expectException(HttpException::class);
-        $this->expectExceptionMessage('Connection refused');
+        try {
+            $provider->getBaseAuthorizationUrl();
+        } catch (HttpException $thrown) {
+            $this->assertSame('Connection refused', $thrown->getMessage());
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertSame($exception, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $provider->getBaseAuthorizationUrl();
+            return;
+        }
+        $this->fail('Expected HttpException');
     }
 
     public function testFetchJsonResourceInvalidJson(): void
@@ -764,9 +842,15 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
-        $this->expectException(\ItkDev\OpenIdConnect\Exception\JsonException::class);
+        try {
+            $provider->getBaseAuthorizationUrl();
+        } catch (\ItkDev\OpenIdConnect\Exception\JsonException $thrown) {
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertInstanceOf(\JsonException::class, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $provider->getBaseAuthorizationUrl();
+            return;
+        }
+        $this->fail('Expected JsonException');
     }
 
     public function testGetJwtVerificationKeysRejectsJwksMissingKeysArray(): void
@@ -978,10 +1062,16 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Invalid cache key');
+        try {
+            $provider->getBaseAuthorizationUrl();
+        } catch (CacheException $thrown) {
+            $this->assertSame('Invalid cache key', $thrown->getMessage());
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertSame($exception, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $provider->getBaseAuthorizationUrl();
+            return;
+        }
+        $this->fail('Expected CacheException');
     }
 
     public function testGetJwtVerificationKeysCacheInvalidArgument(): void
@@ -1017,10 +1107,16 @@ class OpenIdConfigurationProviderTest extends TestCase
             'httpClient' => $mockHttpClient,
         ]);
 
-        $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('Invalid jwks cache key');
+        try {
+            $provider->validateIdToken('token', self::NONCE);
+        } catch (CacheException $thrown) {
+            $this->assertSame('Invalid jwks cache key', $thrown->getMessage());
+            $this->assertSame(0, $thrown->getCode());
+            $this->assertSame($exception, $thrown->getPrevious(), 'Original cause must be chained');
 
-        $provider->validateIdToken('token', self::NONCE);
+            return;
+        }
+        $this->fail('Expected CacheException');
     }
 
     public function testBase64urlDecodeFailure(): void
@@ -1065,7 +1161,7 @@ class OpenIdConfigurationProviderTest extends TestCase
         $mockJWT = \Mockery::mock('overload:Firebase\JWT\JWT', MockJWT::class);
 
         $this->expectException(\ItkDev\OpenIdConnect\Exception\DecodeException::class);
-        $this->expectExceptionMessage('Error url decoding input');
+        $this->expectExceptionMessage('Error url decoding input !!!');
 
         $provider->validateIdToken('token', self::NONCE);
     }


### PR DESCRIPTION
## Summary

First of three scoped follow-ups to #49 killing surviving mutants to push the mutation score above 90%. Targets the largest cluster: exception-contract assertions (33 of 57 escaped mutants).

## Features Added

* Claims/validation failures (`validateIdToken`) assert the complete message including the dynamic part — audience list, issuer, nonce — so the concatenation can't be dropped or reordered undetected
* Wrap-boundary tests (`ValidationException`, `CodeException`, `HttpException`, `JsonException`, `CacheException`, `IdentityProviderException`) assert code `0` and the chained `$previous` cause
* Constructor URL failures assert the offending URL in the message (`BadUrlException`, `IllegalSchemeException`); `DecodeException` asserts the input; `HttpException` asserts the resource URL
* New `testGetIdTokenRejectsInvalidJsonResponse`: invalid JSON from the token endpoint wraps `\JsonException` into `CodeException` (kills a `Catch_` mutant on the union catch)

## Files Changed

* `tests/Security/OpenIdConfigurationProviderTest.php` - assertion strengthening + one new test
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 98 tests, 168 assertions, green
* `vendor/bin/infection` — 24 escaped mutants remaining, down from 57 (Covered Code MSI 71% → 87%)
* PHPStan max level + php-cs-fixer — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)