### PR TITLE
test: pin request factory wiring and zero-boundary option values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Strengthened constructor tests guided by mutation testing: the `jwt`
+  collaborator is asserted to become the request factory, and `0` is
+  asserted to be an accepted boundary value for `cacheDuration` and
+  `leeway`
+
 ## [5.0.0] - 2026-06-02
 
 Reworked exception hierarchy and tightened IdP-payload validations. The runtime

--- a/tests/Security/OpenIdConfigurationProviderTest.php
+++ b/tests/Security/OpenIdConfigurationProviderTest.php
@@ -20,6 +20,7 @@ use ItkDev\OpenIdConnect\Exception\ValidationException;
 use ItkDev\OpenIdConnect\Security\OpenIdConfigurationProvider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Tool\RequestFactory;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemInterface;
@@ -122,6 +123,40 @@ class OpenIdConfigurationProviderTest extends TestCase
             'openIDConnectMetadataUrl' => 'https://some.url/openid-configuration',
             'leeway' => -10,
         ], []);
+    }
+
+    public function testConstructZeroCacheDurationAndLeewayAccepted(): void
+    {
+        $mockCacheItemPool = $this->createStub(CacheItemPoolInterface::class);
+
+        // Zero is a valid boundary value for both options: cache nothing,
+        // tolerate no clock skew. Only negative values are rejected.
+        $provider = new OpenIdConfigurationProvider([
+            'cacheItemPool' => $mockCacheItemPool,
+            'openIDConnectMetadataUrl' => 'https://some.url/openid-configuration',
+            'cacheDuration' => 0,
+            'leeway' => 0,
+        ], []);
+
+        $this->assertInstanceOf(OpenIdConfigurationProvider::class, $provider);
+    }
+
+    public function testConstructWiresJwtCollaboratorAsRequestFactory(): void
+    {
+        $mockCacheItemPool = $this->createStub(CacheItemPoolInterface::class);
+        $requestFactory = new RequestFactory();
+
+        $provider = new OpenIdConfigurationProvider([
+            'cacheItemPool' => $mockCacheItemPool,
+            'openIDConnectMetadataUrl' => 'https://some.url/openid-configuration',
+        ], [
+            'jwt' => $requestFactory,
+        ]);
+
+        // The 'jwt' collaborator must become the provider's request factory;
+        // without the explicit wiring the parent's default factory would be
+        // silently used instead.
+        $this->assertSame($requestFactory, $provider->getRequestFactory());
     }
 
     public function testGenerateState(): void


### PR DESCRIPTION
## Summary

Third of three scoped follow-ups to #49. Targets constructor wiring and option boundaries (3 escaped mutants).

## Features Added

* `testConstructWiresJwtCollaboratorAsRequestFactory`: the `jwt` collaborator must become the provider's request factory — removing the wiring silently substituted the parent's default factory
* `testConstructZeroCacheDurationAndLeewayAccepted`: `0` is a valid boundary for both options (cache nothing / tolerate no clock skew); the `< 0` guards could mutate to `<= 0` undetected — the textbook boundary mutant

## Files Changed

* `tests/Security/OpenIdConfigurationProviderTest.php` - two new tests
* `CHANGELOG.md` - Unreleased bullet

## Test Plan

* `vendor/bin/phpunit` — 99 tests, 162 assertions, green
* `vendor/bin/infection` — kills its 3 targeted mutants (57 → 54 on this branch alone)
* PHPStan max level + php-cs-fixer — clean

## Notes

Combined with #50 and #51 this leaves 13 escaped mutants, all equivalent or contrived (JSON depth-512 literals, random-string default lengths, casts only observable on corrupted cache, an unreachable catch-union member). A final PR will ratchet `minCoveredMsi` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)