### PR TITLE
ci: raise minimum mutation score to 90 and condense changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Strengthened constructor tests guided by mutation testing: the `jwt`
-  collaborator is asserted to become the request factory, and `0` is
-  asserted to be an accepted boundary value for `cacheDuration` and
-  `leeway`
-- Strengthened cache assertions guided by mutation testing: the discovery
-  document and JWKS key map are asserted to be written to the cache with
-  the configured duration under the namespaced key, and a multi-key JWKS
-  is asserted to reach `JWT::decode` in full
-- Strengthened exception assertions guided by mutation testing: thrown
-  messages are asserted in full (including dynamic parts), wrap-boundary
-  exceptions assert code `0` and the chained `$previous` cause, and
-  invalid JSON from the token endpoint is covered
+- Strengthened tests guided by mutation testing; mutation score raised to
+  93% with a CI threshold of 90 (`minCoveredMsi` in `infection.json5`)
 
 ## [5.0.0] - 2026-06-02
 

--- a/infection.json5
+++ b/infection.json5
@@ -5,8 +5,11 @@
     },
     "threads": "max",
     // Minimum mutation score for covered code; enforced locally and in CI.
-    // Baseline measured at 71% — ratchet up as surviving mutants are killed.
-    "minCoveredMsi": 68,
+    // The suite scores 93%; the 13 surviving mutants are equivalent or
+    // contrived (JSON depth literals, RNG default lengths, casts only
+    // observable on corrupted cache). 90 defends the score with headroom
+    // for run-to-run variance.
+    "minCoveredMsi": 90,
     "logs": {
         "text": "infection.log",
         "html": "infection.html",


### PR DESCRIPTION
## Summary

Final follow-up to the mutation-testing rollout (#49–#52), mirroring itk-dev/openid-connect-bundle#51: the suite now scores **93% covered MSI** (185/198 mutants killed), so the bootstrap threshold of 68 is ratcheted to 90.

The 13 surviving mutants are equivalent or contrived rather than test gaps: JSON `depth: 512` literals, random-string default lengths, casts only observable on corrupted cache, an unreachable catch-union member, and an authorization-URL default that league's `getDefaultScopes()` fallback makes equivalent. Chasing them would add contrived tests for no real verification value.

The `[Unreleased]` changelog is condensed: the three per-PR test-strengthening bullets collapse into one final-outcome entry.

## Files Changed

* `infection.json5` - `minCoveredMsi` 68 → 90, comment documents the surviving-mutant rationale
* `CHANGELOG.md` - condensed Unreleased entries

## Test Plan

* `task test:mutation` — 185/198 killed, 93% covered MSI, passes the new 90 threshold
* markdownlint — clean
* The `Mutation tests (8.3, prefer-stable)` check on this PR exercises the new threshold

## Notes

Small conflict expected with #53 (RFC 2606 domains) on `CHANGELOG.md` — whichever merges second, I'll resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)